### PR TITLE
fixed truncation of interface names

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function parse(src) {
     var flagsline = firstline.slice(coionIdx+1).trim();
     var flagsMh = flagsline.match(/^flags=[0-9]+<{1}([A-Z,]*)>{1} mtu ([0-9]+)/);
 
-    ret.name = firstline.slice(0, coionIdx-1);
+    ret.name = firstline.slice(0, coionIdx);
     ret.flags = flagsMh[1].split(',');
     ret.mtu = parseInt(flagsMh[2], 10);
     conf.forEach(function(item) {


### PR DESCRIPTION
 using the `ifconfig` module, which uses THIS module..."name" cuts off interface "number".. i.e.  `en2` is parsed as `en`, etc. this fixes that problem.  makes it possible to reference interfaces by their correct "name"
